### PR TITLE
Cache parsed queries by default

### DIFF
--- a/aiohttp_graphql/render_graphiql.py
+++ b/aiohttp_graphql/render_graphiql.py
@@ -4,7 +4,7 @@ import re
 from aiohttp import web
 
 
-GRAPHIQL_VERSION = '0.11.10'
+GRAPHIQL_VERSION = '0.11.11'
 
 TEMPLATE = '''<!--
 The request to this GraphQL server provided the header "Accept: text/html"


### PR DESCRIPTION
This would need support in GraphQL server core, as per the following PR:
https://github.com/graphql-python/graphql-server-core/pull/7

For simple queries, the main performance issue is the parsing stage, and people usually end up rewriting graphql-server-core (and aiohttp-graphql for people using it) to allow caching, logging etc.

Enabling configurable caching by default in aiohttp-graphql may be useful.