### PR TITLE
Fix for parse body when sending files with multipart

### DIFF
--- a/aiohttp_graphql/graphqlview.py
+++ b/aiohttp_graphql/graphqlview.py
@@ -1,5 +1,6 @@
 from collections import Mapping
 from functools import partial
+import json
 
 from aiohttp import web
 from promise import Promise
@@ -84,10 +85,13 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
                 'application/x-www-form-urlencoded',
                 'multipart/form-data',
             ):
+            data = dict(await request.post())
+            if not data.get("query", None):
+                return json.loads(data['operations'])
             # TODO: seems like a multidict would be more appropriate
             # than casting it and de-duping variables. Alas, it's what
             # graphql-python wants.
-            return dict(await request.post())
+            return data
 
         return {}
 


### PR DESCRIPTION
Recently I tried to send files with multipart and came across the issue where graphql told me that I'm sending the empty query.
I am using apollo-upload-client to send files and I saw that it's indeed sends the query with all necessary parameters, but graph couldn't parse it correctly.
The reason is that this client send the query in the key 'operations' where value is json.
I don't know if they changed it recently, but since it's official client for uploading files with graphql, I think this should be fixed.
I would like to write a tests for it as well, but I think they are kinda broken, at least I couldn't make them run.
Hope to hear from you, thanks for a great library.