### PR TITLE
Add the ability to use a custom backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ gql_view(request)  # <-- the instance is callable and expects a `aiohttp.web.Req
 -   `encoder`: the encoder to use for responses (sensibly defaults to `graphql_server.json_encode`)
 -   `error_formatter`: the error formatter to use for responses (sensibly defaults to `graphql_server.default_format_error`)
 -   `enable_async`: whether `async` mode will be enabled.
+-   `backend`: the backend to be used to create `GraphQLDocument` from a string (sensibly defaults to `graphql.backend.core.GraphQLCoreBackend`).
 
 
 ## Testing

--- a/aiohttp_graphql/graphqlview.py
+++ b/aiohttp_graphql/graphqlview.py
@@ -36,6 +36,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
             encoder=None,
             error_formatter=None,
             enable_async=True,
+            backend=None,
         ):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
@@ -58,6 +59,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
             self.executor,
             AsyncioExecutor,
         )
+        self.backend = backend
         assert isinstance(self.schema, GraphQLSchema), \
             'A Schema is required to be provided to GraphQLView.'
 
@@ -141,6 +143,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
                 context_value=self.get_context(request),
                 middleware=self.middleware,
                 executor=self.executor,
+                backend=self.backend,
             )
 
             awaited_execution_results = await Promise.all(execution_results)


### PR DESCRIPTION
From my point of view, the `backend` is a good place to add some protection(e.g. query depth or complexity). In the custom `backend` it possible to analyze document AST and raise an exception, if the query does not comply with the rules before it will be executed.

`graphql_server.execute_graphql_request`  accepts the parameter `backend` and if it None get default backend.