### PR TITLE
allow execution options passthrough

### DIFF
--- a/aiohttp_graphql/graphqlview.py
+++ b/aiohttp_graphql/graphqlview.py
@@ -36,6 +36,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
             encoder=None,
             error_formatter=None,
             enable_async=True,
+            **execution_options,
         ):
         # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
@@ -58,6 +59,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
             self.executor,
             AsyncioExecutor,
         )
+        self.execution_options = execution_options
         assert isinstance(self.schema, GraphQLSchema), \
             'A Schema is required to be provided to GraphQLView.'
 
@@ -141,6 +143,7 @@ class GraphQLView: # pylint: disable = too-many-instance-attributes
                 context_value=self.get_context(request),
                 middleware=self.middleware,
                 executor=self.executor,
+                **self.execution_options,
             )
 
             awaited_execution_results = await Promise.all(execution_results)


### PR DESCRIPTION
I'd like to pass through extra options to `run_http_query` within `graphql_server`

https://github.com/graphql-python/graphql-server-core/blob/master/graphql_server/__init__.py#L68

In particular I'd like to pass through `validate=False` for local dev convenience.