### PR TITLE
remove trailing comma (fix SyntaxError for old python versions)

### DIFF
--- a/aiohttp_graphql/graphqlview.py
+++ b/aiohttp_graphql/graphqlview.py
@@ -36,7 +36,7 @@ class GraphQLView:  # pylint: disable = too-many-instance-attributes
         error_formatter=None,
         enable_async=True,
         subscriptions=None,
-        **execution_options,
+        **execution_options
     ):
         # pylint: disable=too-many-arguments
 


### PR DESCRIPTION
Issue https://github.com/graphql-python/aiohttp-graphql/issues/23